### PR TITLE
[main] Fix timeout on short CSI calls

### DIFF
--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -167,7 +167,6 @@ func main() {
 	}
 	logger = klog.LoggerWithValues(logger, "driver", csiAttacher)
 	logger.V(2).Info("CSI driver name")
-	cancelationCtx = klog.NewContext(cancelationCtx, logger)
 
 	translator := csitrans.New()
 	if translator.IsMigratedCSIDriverByName(csiAttacher) {
@@ -202,6 +201,9 @@ func main() {
 		}()
 	}
 
+	cancelationCtx, cancel = context.WithTimeout(ctx, csiTimeout)
+	cancelationCtx = klog.NewContext(cancelationCtx, logger)
+	defer cancel()
 	supportsService, err := supportsPluginControllerService(cancelationCtx, csiConn)
 	if err != nil {
 		logger.Error(err, "Failed to check if the CSI Driver supports the CONTROLLER_SERVICE")


### PR DESCRIPTION
The same context.WithTimeout was used in different places when calling the CSI drivers. With recent changes, the code execution started taking longer and the context would hit its timeout on the 2nd driver call. This change use a separate context.WithTimeout for each CSI call

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
